### PR TITLE
Fix leaderboard

### DIFF
--- a/scripts/leaderboard.coffee
+++ b/scripts/leaderboard.coffee
@@ -138,6 +138,11 @@ module.exports = (robot) ->
   # response for score status of any <keyword>
   robot.respond /score ([\w\-_]+)/i, (msg) ->
 
+    # we do not want to reply in case of batch score is requested
+    bxx = /b\d\d/i
+    if bxx.exec(msg.match[0]) != null
+    then return
+
     # data-store object
     ScoreField = scorefield()
 

--- a/scripts/leaderboard.coffee
+++ b/scripts/leaderboard.coffee
@@ -8,7 +8,7 @@
 module.exports = (robot) ->
 
   robot.listenerMiddleware (context, next, done) ->
-    
+
     try
       # Check if it was called in a room.
       if get_channel(context.response) is '#DM'
@@ -26,14 +26,14 @@ module.exports = (robot) ->
       "@#{response.message.room}"
     else
       "##{robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById(response.message.room).name}"
- 
+
   # return object to store data for all keywords
   # using this, stores the data in brain's "scorefield" key
   scorefield = () ->
     Field = robot.brain.get("scorefield") or {}
     robot.brain.set("scorefield",Field)
     Field
-  
+
   detailedfield= () ->
     Field = robot.brain.get("detailedfield") or {}
     robot.brain.set("detailedfield",Field)
@@ -43,7 +43,7 @@ module.exports = (robot) ->
     name = name.toLowerCase()
     lastscore = field[name] or 0
     lastscore
- 
+
   #returns appreciation field associated to a single user
   userFieldMinus = (user) ->
     Detailedfield= detailedfield()
@@ -80,7 +80,7 @@ module.exports = (robot) ->
         userfield= userFieldPlus(name.toLowerCase())
         updateDetailedScore(userfield,username,"plus")
         response= responses[Math.floor(Math.random() * 7)]
- 
+
     # if there is to be `minus` in score
     else if word.indexOf("--") >= 0
       name = word.replace negRegex, ""
@@ -91,38 +91,38 @@ module.exports = (robot) ->
         userfield= userFieldMinus(name.toLowerCase())
         updateDetailedScore(userfield,username,"minus")
         response= "ouch!"
- 
+
     newscore = field[name.toLowerCase()]
- 
+
     # returns 'name' and 'newscore' and 'response'
     New: newscore
     Name: name
     Response: response
- 
- 
+
+
   # listen for any [word](++/--) in chat and react/update score
   robot.hear /[a-zA-Z0-9\-_]+(\-\-|\+\+)/gi, (msg) ->
- 
+
     # message for score update that bot will return
     oldmsg = msg.message.text
- 
+
     # data-store object
     ScoreField = scorefield()
- 
+
     # index keeping an eye on position, where next replace will be
     start = 0
     end = 0
- 
+
     # for each ++/--
     for i in [0...msg.match.length]
       testword = msg.match[i]
- 
+
       # updates Scoring for words, accordingly and returns result string
       result = updateScore(testword, ScoreField, msg.message.user.name)
-      
+
 
       end = start + testword.length
- 
+
       # generates response message for reply
       if result.Response == "-1"
         newmsg = "#{testword} [Sorry, You can't give ++ or -- to yourself.]"
@@ -130,25 +130,25 @@ module.exports = (robot) ->
         newmsg = "#{testword} [#{result.Response} #{result.Name} now at #{result.New}] "
       oldmsg = oldmsg.substr(0, start) + newmsg + oldmsg.substr(end+1)
       start += newmsg.length
- 
+
     # reply with updated message
     msg.send "#{oldmsg}"
- 
- 
+
+
   # response for score status of any <keyword>
   robot.respond /score ([\w\-_]+)/i, (msg) ->
- 
+
     # data-store object
     ScoreField = scorefield()
- 
+
     # <keyword> whose score is to be shown
     name = msg.match[1]
     name = name.toLowerCase()
- 
+
     # current score for keyword
     ScoreField[name] = ScoreField[name] or 0
     currentscore = ScoreField[name]
- 
+
     msg.send "#{name} : #{currentscore}"
 
   robot.on 'plusplus', (event) ->
@@ -156,6 +156,7 @@ module.exports = (robot) ->
     result = updateScore("#{event.username}++", ScoreField, "Shell")
     newmsg = "#{event.username}++ [#{result.Response} #{result.Name} now at #{result.New}]"
     robot.send room: 'general', newmsg
+
 responses = [
   'flamboyant!'
   'baroque!'


### PR DESCRIPTION
The commit a23a7ae ("Add batch-score.coffee", 2019-06-11) added
support to fetch score of the whole batch at once. But it also
introduced a bug: since leaderboard script also listens for
"score <chars>", bot replies twice to our query "score b\d\d".
Since we don't have names containing b\d\d, let's completely ignore
responding to that so that bot doesn't reply twice for the same
query.