### PR TITLE
Integrating google action to post message via google asssistant

### DIFF
--- a/scripts/httpd.coffee
+++ b/scripts/httpd.coffee
@@ -16,6 +16,7 @@
 #   /hubot/time
 #   /hubot/info
 #   /hubot/ip
+#   /hubot/slack
 
 spawn = require('child_process').spawn
 
@@ -40,3 +41,7 @@ module.exports = (robot) ->
   robot.router.get "/hubot/ip", (req, res) ->
     robot.http('http://ifconfig.me/ip').get() (err, r, body) ->
       res.end body
+
+  robot.router.post "/hubot/slack", (req, res) ->
+      message = req.body.queryResult.parameters.message
+      robot.send room: 'general', "Message through google assistant: #{message}"


### PR DESCRIPTION
The Hubot now accepts the google action webhook request to post message or more precisely a general announcement directly through google assistant using the action intent "Ok Google, Talk to slack mdg"

The following steps should be followed:
- Hey google, talk to slack mdg.
- bro send _$message_
- :tada: The _$message_ will be posted on slack by our loved Bot/Bro